### PR TITLE
Fixed repetitive subscriptions and useEffect cleanups

### DIFF
--- a/src/actions/ChatActions.js
+++ b/src/actions/ChatActions.js
@@ -67,8 +67,8 @@ export const ACTIONS = {
  */
 
 export const loadChatData = () => async (dispatch, getState) => {
-  const { hostIP, authToken } = getState().node;
-  const data = await getChats({ hostIP, authToken });
+  const { authToken } = getState().node;
+  const data = await getChats({ authToken });
   console.log("LOAD_CHAT_DATA:", data);
 
   dispatch({
@@ -144,8 +144,7 @@ export const loadReceivedRequests = () => (dispatch, getState) => {
 export const subscribeChatMessages = (
   userPublicKey,
   recipientPublicKey
-) => async (dispatch, getState) => {
-  const { hostIP } = getState().node;
+) => async (dispatch) => {
   const { data: incomingId } = await Http.get(
     `/api/gun/user/once/userToIncoming>${recipientPublicKey}`,
     {

--- a/src/actions/OrdersActions.js
+++ b/src/actions/OrdersActions.js
@@ -75,11 +75,9 @@ export const deleteService = id => async dispatch => {
   });
 };
 
-export const subscribeMyServices = hostIP => async dispatch => {
+export const subscribeMyServices = () => dispatch => {
   const query = `$user::offeredServices::on`;
-  const socketExists = rifleSocketExists(query);
-  const subscription = await rifle({
-    host: hostIP,
+  const subscription = rifle({
     query,
     publicKey: "",
     reconnect: false,
@@ -110,9 +108,7 @@ export const subscribeMyServices = hostIP => async dispatch => {
     }
   });
 
-  return () => {
-    subscription.off();
-  };
+  return subscription;
 };
 
 export const buyService = (

--- a/src/actions/UserProfilesActions.ts
+++ b/src/actions/UserProfilesActions.ts
@@ -1,9 +1,7 @@
 import * as Common from "shock-common";
 
 import * as Utils from "../utils";
-import { unsubscribeRifleById, rifle } from "../utils/WebSocket";
-
-import { setAuthenticated } from "./AuthActions";
+import { rifle, rifleCleanup, unsubscribeRifleByQuery } from "../utils/WebSocket";
 
 export const ACTIONS = {
   RESET_USER_PROFILES: "userProfiles/profiles/reset",
@@ -11,6 +9,8 @@ export const ACTIONS = {
   REMOVE_USER_PROFILE: "userProfiles/profiles/remove",
   UPDATE_USER_PROFILE: "userProfiles/profiles/update"
 };
+
+const subscribedProfiles = new Set();
 
 export const updateUserProfile = (
   publicKey: string,
@@ -26,80 +26,85 @@ export const updateUserProfile = (
 /**
  * Returns an un subscription function.
  */
-export const subscribeUserProfile = (publicKey: string) => async (
+export const subscribeUserProfile = (publicKey: string) => (
   dispatch: (action: object) => void,
   getState: () => {
     userProfiles: Record<string, Common.User>;
   }
 ) => {
+  if (subscribedProfiles.has(publicKey)) {
+    return () => {}
+  }
+
   console.info("subbing user..."+publicKey)
-  const [subscription, binarySub] = await Promise.all([
-    rifle({
-      query: `${publicKey}::Profile::on`,
-      reconnect: true,
-      onData: profile => {
-        console.log("up on profile")
-        console.log(profile)
-        const { [publicKey]: existingUser } = getState().userProfiles;
-    
-        if (existingUser) {
-          dispatch({
-            type: ACTIONS.UPDATE_USER_PROFILE,
-            data: { publicKey, profile }
-          });
-          return profile;
-        }
-    
+  subscribedProfiles.add(publicKey)
+
+  const subscription = rifle({
+    query: `${publicKey}::Profile::on`,
+    reconnect: true,
+    onData: profile => {
+      console.log("up on profile:")
+      console.log(profile)
+      const { [publicKey]: existingUser } = getState().userProfiles;
+  
+      if (existingUser) {
         dispatch({
-          type: ACTIONS.LOAD_USER_PROFILE,
+          type: ACTIONS.UPDATE_USER_PROFILE,
           data: { publicKey, profile }
         });
+        return profile;
       }
-    }),
-    rifle({
-      query: `${publicKey}::profileBinary::map.on`,
-      reconnect: true,
-      onData: (data, key: string) => {
-        if (key === "avatar") {
-          if (typeof data !== "string" && data !== null) {
-            Utils.logger.error(
-              `Expected avatar data to be string or null, instead got: ${typeof data}. Public key: ${publicKey}`
-            );
-            return;
-          }
-          dispatch(
-            updateUserProfile(publicKey, {
-              avatar: data
-            })
-          );
-        } else if (key === "header") {
-          if (typeof data !== "string" && data !== null) {
-            Utils.logger.error(
-              `Expected header data to be string or null, instead got: ${typeof data}. Public key: ${publicKey}`
-            );
-            return;
-          }
-          dispatch(
-            updateUserProfile(publicKey, {
-              header: data
-            })
-          );
-        } else {
+  
+      dispatch({
+        type: ACTIONS.LOAD_USER_PROFILE,
+        data: { publicKey, profile }
+      });
+    }
+  });
+
+  const binarySub = rifle({
+    query: `${publicKey}::profileBinary::map.on`,
+    reconnect: true,
+    onData: (data, key: string) => {
+      if (key === "avatar") {
+        if (typeof data !== "string" && data !== null) {
           Utils.logger.error(
-            `Unknown key: ${key} for user binary profile data gun RPC socket`
+            `Expected avatar data to be string or null, instead got: ${typeof data}. Public key: ${publicKey}`
           );
+          return;
         }
+        dispatch(
+          updateUserProfile(publicKey, {
+            avatar: data
+          })
+        );
+      } else if (key === "header") {
+        if (typeof data !== "string" && data !== null) {
+          Utils.logger.error(
+            `Expected header data to be string or null, instead got: ${typeof data}. Public key: ${publicKey}`
+          );
+          return;
+        }
+        dispatch(
+          updateUserProfile(publicKey, {
+            header: data
+          })
+        );
+      } else {
+        Utils.logger.error(
+          `Unknown key: ${key} for user binary profile data gun RPC socket`
+        );
       }
-    })
-  ]);
+    }
+  });
 
   return () => {
-    binarySub.off();
-    subscription.off();
+    rifleCleanup(subscription, binarySub)();
+    subscribedProfiles.delete(publicKey);
   };
 };
 
 export const unsubscribeUserProfile = (publicKey: string) => async () => {
-  unsubscribeRifleById(`${publicKey}::Profile::on`);
-  unsubscribeRifleById(`${publicKey}::profileBinary::map.on`);
+  unsubscribeRifleByQuery(`${publicKey}::Profile::on`);
+  unsubscribeRifleByQuery(`${publicKey}::profileBinary::map.on`);
 };

--- a/src/common/ContentHostInput/ContentHostInput.tsx
+++ b/src/common/ContentHostInput/ContentHostInput.tsx
@@ -134,11 +134,11 @@ const ContentHostInput = () => {
     [dispatch]
   );
 
+  // @ts-ignore
   useEffect(() => {
-    dispatch(subscribeUserProfile(seedProviderPub));
-    return () => {
-      dispatch(unsubscribeUserProfile(seedProviderPub));
-    };
+    const unsubscribe = dispatch(subscribeUserProfile(seedProviderPub));
+
+    return unsubscribe;
   }, [seedProviderPub, dispatch]);
   const filteredHosts = useMemo(() => {
     return hosts.filter(h => h);

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import * as Store from "../store";
 
-import { rifle } from "../utils/WebSocket";
+import { rifle, rifleCleanup } from "../utils/WebSocket";
 
 export interface Pic {
   id: string;
@@ -14,8 +14,8 @@ export const useStory = (publicKey: string) => {
   const [pics, setPics] = React.useState<readonly Pic[]>([]);
   const { hostIP } = Store.useSelector(state => state.node);
 
-  const subscribeStory = React.useCallback(async () => {
-    const sub = await rifle({
+  const subscribeStory = React.useCallback(() => {
+    const sub = rifle({
       query: `${publicKey}::story::open`,
       onData: (pictures: unknown) => {
         if (typeof pictures !== "object" || pictures === null) {
@@ -32,13 +32,13 @@ export const useStory = (publicKey: string) => {
       }
     });
 
-    return () => {
-      sub.off();
-    };
+    return rifleCleanup(sub);
   }, [hostIP, publicKey]);
 
   React.useEffect(() => {
-    subscribeStory();
+    const unsubscribe = subscribeStory();
+
+    return unsubscribe
   }, [subscribeStory]);
 
   return pics;

--- a/src/pages/Chat/index.js
+++ b/src/pages/Chat/index.js
@@ -18,6 +18,7 @@ import {
 import BitcoinLightning from "../../images/bitcoin-lightning.svg";
 import "./css/index.css";
 import * as Store from "../../store";
+import { rifleCleanup } from "../../utils/WebSocket";
 import { getContact } from "../../utils";
 import * as gStyles from "../../styles";
 /**
@@ -119,20 +120,13 @@ const ChatPage = () => {
       subscribeChatMessages(gunPublicKey, recipientPublicKey)
     );
 
-    return async () => {
-      const resolvedSubscription = await subscription;
-      // @ts-expect-error Until thunks are better typed and also dispatch is
-      // this will throw
-      resolvedSubscription?.off();
-    };
+    return rifleCleanup(subscription);
   }, [dispatch, gunPublicKey, recipientPublicKey]);
 
   useEffect(() => {
     const unsubscribe = subscribeIncomingMessages();
 
-    return () => {
-      unsubscribe();
-    };
+    return unsubscribe;
   }, [subscribeIncomingMessages]);
 
   // ------------------------------------------------------------------------ //

--- a/src/pages/Messages/index.js
+++ b/src/pages/Messages/index.js
@@ -4,6 +4,7 @@ import { useDispatch } from "react-redux";
 import { DateTime } from "luxon";
 
 import { loadChatData, sendHandshakeRequest } from "../../actions/ChatActions";
+import { subscribeUserProfile } from "../../actions/UserProfilesActions";
 import BottomBar from "../../common/BottomBar";
 import Message from "./components/Message";
 import Request from "./components/Request";
@@ -36,6 +37,15 @@ const MessagesPage = () => {
   useEffect(() => {
     loadChat();
   }, [loadChat]);
+
+  useEffect(() => {
+    const subscriptions = [...contacts, ...sentRequests, ...receivedRequests].map(entry => dispatch(subscribeUserProfile(entry.pk)))
+
+    return () => {
+      // @ts-ignore
+      subscriptions.map(unsubscribe => unsubscribe())
+    }
+  }, [contacts, sentRequests, receivedRequests, dispatch])
 
   const toggleModal = useCallback(() => {
     setAddModalOpen(!addModalOpen);

--- a/src/utils/WebSocket.js
+++ b/src/utils/WebSocket.js
@@ -228,7 +228,7 @@ export const unsubscribeRifleById = subscriptionId => {
 export const unsubscribeRifleByQuery = query => {
   const subscriptionEntries = Array.from(rifleSubscriptions.entries());
 
-  const unsubscriptions = subscriptionEntries.map(([id, subscription]) => {
+  subscriptionEntries.map(([id, subscription]) => {
     if (subscription.query === query) {
       console.log("Unsubscribing by query:", subscription)
       unsubscribeRifleById(id);
@@ -237,12 +237,6 @@ export const unsubscribeRifleByQuery = query => {
 
     return false;
   });
-
-  const unsubscribed = unsubscriptions.find(unsubscribed => unsubscribed)
-
-  if (!unsubscribed) {
-    console.error("Couldn't unsubscribe from:", query, subscriptionEntries.map(([id, subscription]) => subscription))
-  }
 };
 
 export const unsubscribeEvent = subscriptionId =>

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -151,7 +151,7 @@ export const retryOperation = <T>(
   });
 
 /**
- * Returns an empty string if the string provided is not an url.
+ * Returns an empty string if the string provided is not a url.
  */
 export const normalizeURL = (_url: string): string => {
   let url = _url;


### PR DESCRIPTION
- Moved subscriptions in App.js to their respective pages (Messages, Profile and Feed)
- Created new `rifleCleanup` function for unsubscribing from existing rifle subscriptions
- Prevent duplicate profile subscriptions
- Migrated all socket subscription useEffects to use rifleCleanup
- Rewritten messages screen subscription functionality