### PR TITLE
Better looking "recent activity" header in overv

### DIFF
--- a/src/pages/Overview/OverviewPage.tsx
+++ b/src/pages/Overview/OverviewPage.tsx
@@ -117,9 +117,10 @@ const OverviewPage = () => {
             <p className="overview-action-text">Request</p>
           </Link>
         </div>
+
+        <p className="recent-activity-title">Recent Activity</p>
       </div>
       <div className="recent-activity-container">
-        <p className="recent-activity-title">Recent Activity</p>
         <PullToRefresh
           className="recent-activity-entries"
           pullingContent={

--- a/src/pages/Overview/css/index.scoped.css
+++ b/src/pages/Overview/css/index.scoped.css
@@ -6,7 +6,7 @@
   position: relative;
   margin-bottom: 0;
   padding-top: 77px;
-  padding-bottom: 37px;
+  padding-bottom: 57px;
   background-image: url(../../../images/waves-bg-dark.svg);
   background-size: cover;
   background-position: 50% 50%;
@@ -76,9 +76,11 @@ p.overview-action-text {
 }
 
 .recent-activity-title {
-  padding: 0px 22px;
+  padding: 0px 25px;
   opacity: 0.7;
-  margin-bottom: 20px;
+  position: absolute;
+  bottom: 16px;
+  left: 0;
 }
 
 .lds-ellipsis div {


### PR DESCRIPTION
before: 

![Screenshot from 2021-07-25 14-25-43](https://user-images.githubusercontent.com/32064271/126909426-69e2b423-ba92-4188-9a97-aa7b860c068d.png)


after:

![Screenshot from 2021-07-25 14-26-40](https://user-images.githubusercontent.com/32064271/126909414-c988fe6f-41f8-4462-b520-e49ac27354e9.png)
