### PR TITLE
Memoize useLastSeen hook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16629,6 +16629,11 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
     },
+    "use-between": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/use-between/-/use-between-0.0.18.tgz",
+      "integrity": "sha512-AcURSNnxI7jMBYe/jfzKNfEtZEHJPmM7dHOu43BYqboZXito+pIQxt2cmKMB0AVKshJELCSfznaYIqnOYNtg+A=="
+    },
     "use-composed-ref": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "socket.io-client": "^4.0.1",
     "socket.io-msgpack-parser": "^3.0.1",
     "typescript": "^4.2.4",
+    "use-between": "0.0.18",
     "use-onclickoutside": "^0.3.1",
     "uuid": "^8.3.2",
     "video.js": "^7.11.8",

--- a/src/common/ShockAvatar/index.tsx
+++ b/src/common/ShockAvatar/index.tsx
@@ -51,7 +51,7 @@ const ShockAvatar: React.FC<ShockAvatarProps> = ({
 }) => {
   const avatarImageFileInput = useRef<HTMLInputElement>(null);
   const [settingAvatar, setSettingAvatar] = useState<boolean>(false);
-  const { lastSeenApp, lastSeenNode } = Utils.useLastSeen(publicKey);
+  const { lastSeenApp, lastSeenNode } = Utils.useLastSeenShared(publicKey);
   const selfPublicKey = Store.useSelector(Store.selectSelfPublicKey);
   const isSelf = publicKey === selfPublicKey;
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -3,11 +3,13 @@ import { useCallback, useEffect, useState } from "react";
 import { Action } from "redux";
 import { useDispatch as originalUseDispatch } from "react-redux";
 import { ThunkDispatch } from "redux-thunk";
+import { useBetween } from "use-between";
 
 import { State } from "../reducers";
 import { Contact, ReceivedRequest, SentRequest } from "../schema";
 
 import { rifle } from "./WebSocket";
+import { memoize } from "lodash";
 
 export * from "./Date";
 export { default as Http } from "./Http";
@@ -277,3 +279,10 @@ export const useLastSeen = (publicKey: string) => {
 
   return { lastSeenApp, lastSeenNode };
 };
+
+const useLastSeenMemo = memoize((publicKey: string) => {
+  return () => useLastSeen(publicKey);
+});
+
+export const useLastSeenShared = (publicKey: string) =>
+  useBetween(useLastSeenMemo(publicKey));


### PR DESCRIPTION
Previously, *each* avatar component used to create a new GunDB subscription to track the user's subscription status so even if two avatars are being rendered for the same user, two GunDB subscriptions would be created.

This PR should fix that behavior and have the app create new GunDB lastSeen subscriptions only when the avatar being displayed is unique, so if two avatars are being rendered for the same user, only one GunDB subscription would be created.