### PR TITLE
Upgrade shock-common to v40.0.1 (initial values)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14831,9 +14831,9 @@
       "optional": true
     },
     "shock-common": {
-      "version": "41.0.0",
-      "resolved": "https://registry.npmjs.org/shock-common/-/shock-common-41.0.0.tgz",
-      "integrity": "sha512-kX4RQTvL9pwBxTIVJOqIcmvcsZ1ZrNQRX+ebu4zrm+202M1qSCZUi8cp8aC3JK5Oab3wOzX0T6AWEuTyvbLrqQ==",
+      "version": "41.0.1",
+      "resolved": "https://registry.npmjs.org/shock-common/-/shock-common-41.0.1.tgz",
+      "integrity": "sha512-UCCgBfJgQ6nBr8iJWV173aLrjGrKnNC0scRoiQBhdwNIOtLjRWlM/s/GWRcUa4TWWhZKTD4x/PznhpLvSd4oRA==",
       "requires": {
         "immer": "^6.0.6",
         "lodash": "^4.17.19",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "redux-persist": "^6.0.0",
     "redux-thunk": "^2.3.0",
     "reselect": "^4.0.0",
-    "shock-common": "^41.0.0",
+    "shock-common": "^41.0.1",
     "socket.io-client": "^4.0.1",
     "socket.io-msgpack-parser": "^3.0.1",
     "typescript": "^4.2.4",


### PR DESCRIPTION
Now provides initial values for a user's display name and bio